### PR TITLE
로그인 세션 관리를 위한 Redis 추가 및 설정, 회원 API 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // bean validation 사용
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis' // 로그인 세션 정보를 NoSQL 서비스 중 하나인 Redis에 Key-Value 형태로 관리
+
 	runtimeOnly 'mysql:mysql-connector-java'
 
 	compileOnly 'org.projectlombok:lombok' // Lombok으로 반복적인 코드를 어노테이션을 적용하여 간소화

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,9 @@
+# JSON과 Object를 매핑하는 Java 라이브러리인 Jackson에서 JSON deserialize가 되지 않는 이슈 관련 해결법
+# 1.16.20 version BREAKING CHANGE
+# lombok config key lombok.anyConstructor.suppressConstructorProperties is now deprecated and defaults to true,
+# that is, by default lombok no longer automatically generates @ConstructorProperties annotations.
+# New config key lombok.anyConstructor.addConstructorProperties now exists;
+# set it to true if you want the old behavior.
+# Oracle more or less broke this annotation with the release of JDK9, necessitating this breaking change.
+# https://projectlombok.org/changelog
+lombok.anyConstructor.addConstructorProperties=true

--- a/src/main/java/com/cucumber/market/config/RedisConfig.java
+++ b/src/main/java/com/cucumber/market/config/RedisConfig.java
@@ -1,0 +1,73 @@
+package com.cucumber.market.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession // 세션을 Redis에 저장. 여러 WAS를 사용해도 세션을 하나의 Redis에서 관리할 수 있음
+public class RedisConfig {
+    @Value("${cucumber.market.redis.host}")
+    private String redisHost;
+
+    @Value("${cucumber.market.redis.port}")
+    private int redisPort;
+
+    @Value("${cucumber.market.redis.password}")
+    private String redisPwd;
+
+    /*
+     * 클래스(Object)와 JSON의 매핑을 담당
+     *
+     * JSON -> Object : readValue()
+     * 사용 예시
+     * 1) JSON에서 Object로 변환
+     * 2) JSON File을 읽어 Object로 변환
+     * 3) URI 정보로 리소스에 접근하여 리소스를 읽어온 후 Object로 변환
+     * 4) String 형식의 JSON 데이터를 Object로 변환
+     *
+     * Object -> JSON : writeValue()
+     * 사용 예시
+     * 1) Object를 JSON File로 변환 후 저장
+     * 2) byte[] 형태로 Object를 저장
+     * 3) String 형태로 Object를 JSON형태로 저장
+     *
+     * writerWithDefaultPrettyPrint().writeValueAs... JSON 파일이 정렬된 상태로 저장
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module());
+        return mapper;
+    }
+
+    /*
+     * Redis Client 서비스 비교분석
+     *
+     * Lettuce
+     * Tomcat이 아니라 Netty 기반. 따라서 비동기 이벤트 기반으로 요청하기 때문에 Jedis에 비해 높은 성능을 가짐
+     * TPS, CPU, Connection 개수, 응답속도 모두 Jedis에 비해 우수한 성능을 보인다는 테스트 사례가 있음
+     *
+     * Jedis
+     * Connection pool을 사용하여 성능 향상과 안정성 개선이 가능하지만 Lettuce보다 상대적으로 하드웨어적인 자원이 많이 필요
+     * 비동기 기능을 제공하지 않음
+     * 멀티쓰레드환경에서 쓰레드 안전을 보장하지 않음
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPassword(redisPwd);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+}

--- a/src/main/java/com/cucumber/market/controller/MemberController.java
+++ b/src/main/java/com/cucumber/market/controller/MemberController.java
@@ -10,13 +10,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
-/**
- * @Slf4j
- * @RestController
- * @RequiredArgsConstructor
- * @RequestMapping("/members")
+/*
+@RestController
+ - @Controller에 @ResponseBody가 추가된 어노테이션
+   @RequestMapping 메소드를 처리할 때 @ResponseBody가 기본적으로 붙으면서 처리됨
+
+@RequestMapping
+ - 요청 URL을 처리할 클래스나 메소드에 연결시키는 어노테이션
+
+@Valid
+ - 클래스에 정의된 제약조건을 바탕으로 지정된 아규먼트에 대한 유효성 검사 실시
+   build.gradle 의존관계 추가가 필요
+   @Validated 는 스프링 전용 검증 애노테이션이고, @Valid 는 자바 표준 검증 애노테이션이다. 둘중
+   아무거나 사용해도 동일하게 작동하지만, @Validated 는 내부에 groups 라는 기능을 포함하고 있다.
  */
 
 @Slf4j
@@ -28,6 +37,7 @@ public class MemberController {
     // TODO: 2021-12-01 HandlerMethodArgumentResolver를 사용해서 특정 Request 객체에 대해 처리 (예 : 패스워드 암호화)
 
     private final MemberService memberService;
+
     /**
      * @ModelAttribute 는 필드 단위로 정교하게 바인딩이 적용된다. 특정 필드가 바인딩 되지 않아도 나머지
      * 필드는 정상 바인딩 되고, Validator를 사용한 검증도 적용할 수 있다.
@@ -48,7 +58,7 @@ public class MemberController {
 
     // 회원조회(회원정보)
     @GetMapping("/myInfo")
-    public ResponseEntity<MemberDTO> findMemberInfo(@Valid MemberIdPasswordRequest request) {
+    public ResponseEntity<MemberDTO> findMemberInfo(@Valid MemberMyInfoRequest request) {
         return new ResponseEntity<>(memberService.findMemberInfo(request), HttpStatus.OK);
     }
 
@@ -64,4 +74,19 @@ public class MemberController {
         return new ResponseEntity<>(memberService.inactivateMember(request), HttpStatus.FOUND);
     }
 
+    // 로그인
+    @PostMapping("/signIn")
+    public ResponseEntity<MemberSignInResponse> signInMember(@Valid @RequestBody MemberIdPasswordRequest request, HttpSession httpSession) {
+        MemberSignInResponse response = memberService.signInMember(request);
+
+        // TODO: 2021-12-02 Controller에서 getAttribute, setAttribute를 직접 해주는건 좋지 않은 구조일까?
+//        if(httpSession.getAttribute("signIn") != null) {
+//            return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+//        } else {
+//            httpSession.setAttribute("signIn", response);
+//            return new ResponseEntity<>(response, HttpStatus.OK);
+//        }
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/cucumber/market/controller/dto/MemberMyInfoRequest.java
+++ b/src/main/java/com/cucumber/market/controller/dto/MemberMyInfoRequest.java
@@ -1,12 +1,13 @@
 package com.cucumber.market.controller.dto;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
-public class MemberIdPasswordRequest {
+public class MemberMyInfoRequest {
     @NotBlank(message = "아이디를 입력해주세요.")
     private final String member_id;
 

--- a/src/main/java/com/cucumber/market/controller/dto/MemberSignInResponse.java
+++ b/src/main/java/com/cucumber/market/controller/dto/MemberSignInResponse.java
@@ -1,0 +1,11 @@
+package com.cucumber.market.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberSignInResponse {
+    private String member_id;
+    private String name;
+}

--- a/src/main/java/com/cucumber/market/controller/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/cucumber/market/controller/dto/MemberSignUpRequest.java
@@ -1,7 +1,6 @@
 package com.cucumber.market.controller.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -11,18 +10,18 @@ import javax.validation.constraints.Pattern;
 public class MemberSignUpRequest {
 
     @NotBlank(message = "아이디를 입력해주세요.")
-    private String member_id;
+    private final String member_id;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String password;
+    private final String password;
 
     @NotBlank(message = "이름을 입력해주세요.")
-    private String name;
+    private final String name;
 
     @NotBlank(message = "전화번호를 입력해주세요.")
     @Pattern(regexp = "[0-9]{8,20}", message = "전화번호는 8~20자리의 숫자만 입력이 가능합니다.")
-    private String phone;
+    private final String phone;
 
     @NotBlank(message = "주소를 입력해주세요.")
-    private String address;
+    private final String address;
 }

--- a/src/main/java/com/cucumber/market/controller/dto/MemberUpdateInfoRequest.java
+++ b/src/main/java/com/cucumber/market/controller/dto/MemberUpdateInfoRequest.java
@@ -1,32 +1,39 @@
 package com.cucumber.market.controller.dto;
 
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+
+/*
+@NoArgsConstructor(force = true)
+기본 생성자는 아무 파라미터도 없기 때문에
+필드가 final로 정의되어 있는 경우 필드를 초기화 할 수 없어
+기본 생성자를 만들 수 없고 에러가 발생
+이 때 force 옵션을 true로 설정하면 final 필드를 기본값으로 강제로 초기화 시켜 생성자를 만들 수 있음
+ */
 
 @Getter
 @Builder
 public class MemberUpdateInfoRequest {
 
     @NotBlank(message = "아이디를 입력해주세요.")
-    private String member_id;
+    private final String member_id;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    private String oldPassword;
+    private final String oldPassword;
 
     @NotBlank(message = "변경할 비밀번호를 입력해주세요.")
-    private String newPassword;
+    private final String newPassword;
 
     @NotBlank(message = "변경할 이름을 입력해주세요.")
-    private String name;
+    private final String name;
 
     @NotBlank(message = "변경할 전화번호를 입력해주세요.")
     @Pattern(regexp = "[0-9]{8,20}", message = "전화번호는 8~20자리의 숫자만 입력이 가능합니다.")
-    private String phone;
+    private final String phone;
 
     @NotBlank(message = "변경할 주소를 입력해주세요.")
-    private String address;
+    private final String address;
 }

--- a/src/main/java/com/cucumber/market/mapper/MemberMapper.java
+++ b/src/main/java/com/cucumber/market/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.cucumber.market.mapper;
 
 import com.cucumber.market.controller.dto.MemberIdPasswordRequest;
+import com.cucumber.market.controller.dto.MemberSignInResponse;
 import com.cucumber.market.controller.dto.MemberSignUpRequest;
 import com.cucumber.market.controller.dto.MemberUpdateInfoRequest;
 import com.cucumber.market.model.member.MemberDTO;
@@ -14,7 +15,9 @@ public interface MemberMapper {
 
     MemberDTO findByMemberId(String member_id);
 
-    void inactivateMember(MemberIdPasswordRequest memberSignUpRequest);
-
     void updateMemberInfo(MemberUpdateInfoRequest memberUpdateInfoRequest);
+
+    void inactivateMember(MemberIdPasswordRequest memberIdPasswordRequest);
+
+    MemberSignInResponse findByMemberIdAndPassword(MemberIdPasswordRequest memberIdPasswordRequest);
 }

--- a/src/main/java/com/cucumber/market/service/MemberService.java
+++ b/src/main/java/com/cucumber/market/service/MemberService.java
@@ -9,9 +9,11 @@ public interface MemberService {
 
     void isDuplicateMemberId(String member_id);
 
-    MemberInactivateResponse inactivateMember(MemberIdPasswordRequest memberInactivateRequest);
-
     MemberUpdateInfoResponse updateMemberInfo(MemberUpdateInfoRequest memberUpdateInfoRequest);
 
-    MemberDTO findMemberInfo(MemberIdPasswordRequest memberIdPasswordRequest);
+    MemberInactivateResponse inactivateMember(MemberIdPasswordRequest memberInactivateRequest);
+
+    MemberDTO findMemberInfo(MemberMyInfoRequest memberMyInfoRequest);
+
+    MemberSignInResponse signInMember(MemberIdPasswordRequest memberIdPasswordRequest);
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -2,3 +2,9 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/cucumber-market?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=111111
+
+# redis
+spring.data.redis.repositories.enabled=true
+cucumber.market.redis.host=localhost
+cucumber.market.redis.port=6379
+cucumber.market.redis.password=

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,3 +2,9 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/cucumber-market?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=111111
+
+# redis
+spring.data.redis.repositories.enabled=true
+cucumber.market.redis.host=localhost
+cucumber.market.redis.port=6379
+cucumber.market.redis.password=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,4 +11,7 @@ cucumber.login.url=www.cucumber-market.com/login
 cucumber.myInfo.url=www.cucumber-market.com/myInfo
 
 # MyBatis
-mybatis.mapper-locations:classpath:mapper/*.xml
+mybatis.mapper-locations=classpath:mapper/*.xml
+
+# session
+spring.session.store-type=redis

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -24,12 +24,8 @@
 
     <update id="updateMemberInfo" parameterType="com.cucumber.market.controller.dto.MemberUpdateInfoRequest">
         UPDATE member
-        SET password = #{newPassword},
-        name = #{name},
-        phone = #{phone},
-        address = #{address}
+        SET password = #{newPassword}, name = #{name}, phone = #{phone}, address = #{address}
         WHERE member_id = #{member_id}
-        AND password = #{oldPassword}
     </update>
 
     <update id="inactivateMember" parameterType="com.cucumber.market.controller.dto.MemberIdPasswordRequest">
@@ -38,4 +34,13 @@
         WHERE member_id = #{member_id}
         AND password = #{password}
     </update>
+
+    <select id="findByMemberIdAndPassword"
+            parameterType="com.cucumber.market.controller.dto.MemberIdPasswordRequest"
+            resultType="com.cucumber.market.controller.dto.MemberSignInResponse">
+        SELECT member_id, name
+        FROM member
+        WHERE member_id = #{member_id}
+        AND password = #{password}
+    </select>
 </mapper>


### PR DESCRIPTION
**회원 API 버그 내용**
- 원인 : Request DTO의 구조적인 문제로 인한 JSON 데이터 파싱 문제

DTO는 immutable한 객체의 개념이기 때문에 각 필드가 final 이어야함
그런데, 기본 생성자는 아무 파라미터도 없기 때문에
필드가 final로 정의되어 있는 경우 필드를 초기화 할 수 없어서 기본 생성자를 만들 수 없고 에러가 발생

- 해결 방법은 총 2가지
1. Lombok 라이브러리에서 제공하는  `@NoArgsConstructor`을 force 옵션을 true로 설정하면 final 필드를 기본값으로 강제로 초기화 시켜 생성자를 만들 수 있음
`@NoArgsConstructor(force = true)`
2. `lombok.anyConstructor.addConstructorProperties=true`
![image](https://user-images.githubusercontent.com/86584999/144280447-52da7c12-0da0-4b22-921d-326be4b6dc01.png)

+ immutable한 DTO를 위한 선택사항 : `@Value`
https://projectlombok.org/features/Value
