### PR TITLE
판매글 상세조회 API 구현, 판매글 등록 API에서 Multipart 관련 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis' // 로그인 세션 정보를 NoSQL 서비스 중 하나인 Redis에 Key-Value 형태로 관리
 
+	implementation 'commons-fileupload:commons-fileupload:1.4' // Multipart Resolver 등록
+	implementation 'commons-io:commons-io:2.8.0' // Multipart Resolver 등록
+
 	runtimeOnly 'mysql:mysql-connector-java' // mysql 연결을 위한 커넥터
 
 	compileOnly 'org.projectlombok:lombok' // Lombok으로 반복적인 코드를 어노테이션을 적용하여 간소화

--- a/src/main/java/com/cucumber/market/CucumberMarketApplication.java
+++ b/src/main/java/com/cucumber/market/CucumberMarketApplication.java
@@ -2,6 +2,7 @@ package com.cucumber.market;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration;
 
 @SpringBootApplication
 public class CucumberMarketApplication {

--- a/src/main/java/com/cucumber/market/CucumberMarketApplication.java
+++ b/src/main/java/com/cucumber/market/CucumberMarketApplication.java
@@ -2,7 +2,6 @@ package com.cucumber.market;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration;
 
 @SpringBootApplication
 public class CucumberMarketApplication {

--- a/src/main/java/com/cucumber/market/config/ArgumentResolverConfig.java
+++ b/src/main/java/com/cucumber/market/config/ArgumentResolverConfig.java
@@ -2,8 +2,10 @@ package com.cucumber.market.config;
 
 import com.cucumber.market.CurrentMemberArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -20,5 +22,13 @@ public class ArgumentResolverConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 
         resolvers.add(currentMemberArgumentResolver);
+    }
+
+    @Bean
+    public CommonsMultipartResolver multipartResolver() {
+        CommonsMultipartResolver commonsMultipartResolver = new CommonsMultipartResolver();
+        commonsMultipartResolver.setDefaultEncoding("UTF-8");
+        commonsMultipartResolver.setMaxUploadSizePerFile(5 * 1024 * 1024);
+        return commonsMultipartResolver;
     }
 }

--- a/src/main/java/com/cucumber/market/config/SpringfoxConfig.java
+++ b/src/main/java/com/cucumber/market/config/SpringfoxConfig.java
@@ -3,7 +3,6 @@ package com.cucumber.market.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -25,12 +24,6 @@ public class SpringfoxConfig implements WebMvcConfigurer {
                 .paths(PathSelectors.any()) // apis() 에 있는 API 중 특정 path 를 선택
                 .build()
                 .apiInfo(apiInfo()); // Springfox 문서화 UI로 노출할 정보
-    }
-
-    @Override
-    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
 
     /*

--- a/src/main/java/com/cucumber/market/config/SpringfoxConfig.java
+++ b/src/main/java/com/cucumber/market/config/SpringfoxConfig.java
@@ -3,6 +3,7 @@ package com.cucumber.market.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -25,6 +26,12 @@ public class SpringfoxConfig implements WebMvcConfigurer {
                 .build()
                 .apiInfo(apiInfo()); // Springfox 문서화 UI로 노출할 정보
     }
+
+//    @Override
+//    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+//        registry.addResourceHandler("swagger-ui.html").addResourceLocations("classpath:/META-INF/resources/");
+//        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+//    }
 
     /*
        API 문서화 및 테스트를 가능케 해주는 Springfox

--- a/src/main/java/com/cucumber/market/controller/ProductController.java
+++ b/src/main/java/com/cucumber/market/controller/ProductController.java
@@ -51,7 +51,7 @@ public class ProductController {
 
     // TODO: 2021-12-07 이미지 파일업로드 보안정책 고려, 예외처리방식 리팩토링, 글,이미지 등록 리스폰스 고려
     // 판매글 등록(썸네일, 상세이미지 포함)
-    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping
     @CheckSignIn
     public ResponseEntity<ProductUploadResponse> uploadProduct(@ModelAttribute ProductUploadRequest request,
                                                                @CurrentMember CurrentMemberInfo currentMemberInfo) throws IOException {

--- a/src/main/java/com/cucumber/market/controller/ProductController.java
+++ b/src/main/java/com/cucumber/market/controller/ProductController.java
@@ -67,7 +67,7 @@ public class ProductController {
     }
 
     // 판매글 검색 및 조회(최신순 페이징, 분류, 제목 검색기능 포함)
-    @GetMapping("{productIdx}")
+    @GetMapping
     public ResponseEntity<List<FindProductResponse>> findProductByPagination(@RequestParam(defaultValue = "1") Integer pageNum,
                                                                              @RequestParam(defaultValue = "10") Integer contentNum,
                                                                              @Valid FindProductRequest request) {
@@ -75,7 +75,14 @@ public class ProductController {
         return new ResponseEntity<>(productService.findProductByPagination(pageNum, contentNum, request.getSmallCategoryName(), request.getTitle()), HttpStatus.OK);
     }
 
-    // 판매글 상세조회 -> 응답 -> 글번호, 제목, 가격, 배송비, 작성자, 내용, 모든 이미지 경로, 글번호에 속한 댓글번호, 대댓글번호
+    // 판매글 상세조회
+    @GetMapping("{productIdx}")
+    public ResponseEntity<FindDetailProductResponse> findDetailProduct(@PathVariable("productIdx") int productIdx) {
+        productService.checkExistProduct(productIdx);
+        productService.checkNotDeleteProduct(productIdx);
+
+        return new ResponseEntity<>(productService.findDetailProduct(productIdx), HttpStatus.OK);
+    }
 
     // 판매글 수정
     @PatchMapping("/{productIdx}/update")

--- a/src/main/java/com/cucumber/market/controller/ProductController.java
+++ b/src/main/java/com/cucumber/market/controller/ProductController.java
@@ -51,7 +51,7 @@ public class ProductController {
 
     // TODO: 2021-12-07 이미지 파일업로드 보안정책 고려, 예외처리방식 리팩토링, 글,이미지 등록 리스폰스 고려
     // 판매글 등록(썸네일, 상세이미지 포함)
-    @PostMapping
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @CheckSignIn
     public ResponseEntity<ProductUploadResponse> uploadProduct(@ModelAttribute ProductUploadRequest request,
                                                                @CurrentMember CurrentMemberInfo currentMemberInfo) throws IOException {

--- a/src/main/java/com/cucumber/market/controller/ProductController.java
+++ b/src/main/java/com/cucumber/market/controller/ProductController.java
@@ -7,9 +7,9 @@ import com.cucumber.market.dto.product.*;
 import com.cucumber.market.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
@@ -46,24 +46,30 @@ public class ProductController {
 //            @CurrentMember CurrentMemberInfo currentMemberInfo) throws IOException {
 //        return new ResponseEntity<>(productService.uploadProductV2(productUploadRequest, multipartFiles, currentMemberInfo.getMember_id()), HttpStatus.OK);
 //    }
+
     // 판매글 관련
 
-    // 판매글 등록
-    @PostMapping
+    // TODO: 2021-12-07 이미지 파일업로드 보안정책 고려, 예외처리방식 리팩토링, 글,이미지 등록 리스폰스 고려
+    // 판매글 등록(썸네일, 상세이미지 포함)
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @CheckSignIn
-    public ResponseEntity<ProductUploadResponse> uploadProduct(@RequestBody ProductUploadRequest request,
-                                                               @CurrentMember CurrentMemberInfo currentMemberInfo) {
+    public ResponseEntity<ProductUploadResponse> uploadProduct(@ModelAttribute ProductUploadRequest request,
+                                                               @CurrentMember CurrentMemberInfo currentMemberInfo) throws IOException {
+        categoryService.checkExistBigCategoryName(request.getBigCategoryName());
+        categoryService.checkExistSmallCategoryName(request.getSmallCategoryName());
+        categoryService.checkBigCategoryIncludeSmallCategory(request.getBigCategoryName(), request.getSmallCategoryName());
 
-        return new ResponseEntity<>(productService.uploadProduct(request, currentMemberInfo.getMember_id()), HttpStatus.OK);
-    }
-
-    // 판매글 등록 시 함께 호출될 썸네일 이미지, 상세페이지 이미지 등록 TODO: 2021-12-07 이미지 파일업로드 보안정책 고려, 예외처리방식 리팩토링, 글,이미지 등록 리스폰스 고려
-    @PostMapping("/images")
-    @CheckSignIn
-    public ResponseEntity<ProductUploadResponse> uploadProductImages(@RequestPart List<MultipartFile> images,
-                                                                     @CurrentMember CurrentMemberInfo currentMemberInfo) throws IOException {
-
-        return new ResponseEntity<>(productService.uploadProductImages(images, currentMemberInfo.getMember_id()), HttpStatus.OK);
+        ProductUploadRequest productUploadRequest = ProductUploadRequest.builder()
+                .bigCategoryName(request.getBigCategoryName())
+                .smallCategoryName(request.getSmallCategoryName())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .price(request.getPrice())
+                .deliveryPrice(request.getDeliveryPrice())
+                .member_id(currentMemberInfo.getMember_id())
+                .build();
+        productService.uploadProduct(productUploadRequest);
+        return new ResponseEntity<>(productService.uploadProductImages(request.getImages(), currentMemberInfo.getMember_id()), HttpStatus.OK);
     }
 
     // 판매글 검색 및 조회(최신순 페이징, 분류, 제목 검색기능 포함)
@@ -181,7 +187,7 @@ public class ProductController {
         return ResponseEntity.ok().build();
     }
 
-    // 댓글삭제
+    // 댓글삭제(비활성화)
     @PatchMapping("/comments/{commentIdx}/delete")
     @CheckSignIn
     public ResponseEntity<Void> deleteComment(@PathVariable int commentIdx,
@@ -219,7 +225,7 @@ public class ProductController {
         replyService.checkNotDeleteReply(replyIdx);
 
         // 현재 로그인한 사람이 댓글 작성자라면 판매자가 작성한 대댓글을 볼 수 있어야된다
-        if(commentService.isCommentWriter(commentIdx, currentMemberInfo.getMember_id())) {
+        if (commentService.isCommentWriter(commentIdx, currentMemberInfo.getMember_id())) {
             return new ResponseEntity<>(replyService.getReply(replyIdx), HttpStatus.OK);
         } else { // 판매글 작성자거나 대댓글 작성자면
             productService.checkProductOrReplyWriter(productIdx, replyIdx, currentMemberInfo.getMember_id());
@@ -240,7 +246,7 @@ public class ProductController {
         return ResponseEntity.ok().build();
     }
 
-    // 대댓글삭제
+    // 대댓글삭제(비활성화)
     @PatchMapping("/comments/replies/{replyIdx}/delete")
     @CheckSignIn
     public ResponseEntity<Void> deleteReply(@PathVariable int replyIdx,

--- a/src/main/java/com/cucumber/market/dto/product/FindDetailProductResponse.java
+++ b/src/main/java/com/cucumber/market/dto/product/FindDetailProductResponse.java
@@ -1,0 +1,32 @@
+package com.cucumber.market.dto.product;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindDetailProductResponse {
+    // 판매글 상세정보 글번호, 작성자, 제목, 내용, 가격, 배송비,  글상태, 수정시간, 해당글의 모든 이미지 경로, 글번호에 속한 댓글번호, 대댓글번호
+    private final String productIdx;
+
+    private final String member_id;
+
+    private final String title;
+
+    private final String content;
+
+    private final String price;
+
+    private final String deliveryPrice;
+
+    private final String status;
+
+    private final String updateTime;
+
+    private final String images;
+
+    private final String comments;
+
+    private final String replies;
+
+}

--- a/src/main/java/com/cucumber/market/dto/product/MultiPartsRequestPayload.java
+++ b/src/main/java/com/cucumber/market/dto/product/MultiPartsRequestPayload.java
@@ -1,0 +1,17 @@
+package com.cucumber.market.dto.product;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class MultiPartsRequestPayload {
+    private String name;
+    private String brand;
+    private MultipartFile file;
+}
+
+
+
+

--- a/src/main/java/com/cucumber/market/dto/product/ProductUploadRequest.java
+++ b/src/main/java/com/cucumber/market/dto/product/ProductUploadRequest.java
@@ -2,9 +2,11 @@ package com.cucumber.market.dto.product;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+import java.util.List;
 
 @Getter
 @Builder
@@ -28,6 +30,9 @@ public class ProductUploadRequest {
     @NotBlank(message = "배송비를 입력해주세요.")
     @Pattern(regexp = "[0-9]", message = "배송비는 숫자만 입력이 가능합니다.")
     private final String deliveryPrice;
+
+    @NotBlank
+    private final List<MultipartFile> images;
 
     private final String member_id;
 

--- a/src/main/java/com/cucumber/market/exception/BigCategoryNotIncludeSmallCategory.java
+++ b/src/main/java/com/cucumber/market/exception/BigCategoryNotIncludeSmallCategory.java
@@ -1,0 +1,11 @@
+package com.cucumber.market.exception;
+
+public class BigCategoryNotIncludeSmallCategory extends RuntimeException {
+    public BigCategoryNotIncludeSmallCategory() {
+        super();
+    }
+
+    public BigCategoryNotIncludeSmallCategory(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cucumber/market/exception/NotExistProductException.java
+++ b/src/main/java/com/cucumber/market/exception/NotExistProductException.java
@@ -1,0 +1,11 @@
+package com.cucumber.market.exception;
+
+public class NotExistProductException extends RuntimeException {
+    public NotExistProductException() {
+        super();
+    }
+
+    public NotExistProductException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cucumber/market/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/cucumber/market/exception/advice/GlobalExceptionHandler.java
@@ -228,4 +228,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // 글번호에 해당하는 판매글이 존재하지 않는 경우
+    @ExceptionHandler(NotExistProductException.class)
+    public ResponseEntity<ExceptionResponse> notExistProductException(final NotExistProductException ex) {
+        log.error(ex.getMessage(), ex);
+        ExceptionResponse response = new ExceptionResponse(ex.getLocalizedMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/src/main/java/com/cucumber/market/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/cucumber/market/exception/advice/GlobalExceptionHandler.java
@@ -236,4 +236,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // 대분류에 속하지않는 소분류명 일때
+    @ExceptionHandler(BigCategoryNotIncludeSmallCategory.class)
+    public ResponseEntity<ExceptionResponse> bigCategoryNotIncludeSmallCategory(final BigCategoryNotIncludeSmallCategory ex) {
+        log.error(ex.getMessage(), ex);
+        ExceptionResponse response = new ExceptionResponse(ex.getLocalizedMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/cucumber/market/mapper/CategoryMapper.java
+++ b/src/main/java/com/cucumber/market/mapper/CategoryMapper.java
@@ -5,6 +5,7 @@ import com.cucumber.market.dto.category.SmallCategoryNamesResponse;
 import com.cucumber.market.dto.category.SmallCategoryRegisterRequest;
 import com.cucumber.market.dto.category.SmallCategoryUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -23,5 +24,7 @@ public interface CategoryMapper {
     int checkDuplicateSmallCategoryName(String smallCategoryName);
 
     void updateSmallCategory(SmallCategoryUpdateRequest smallCategoryUpdateRequest);
+
+    int checkBigCategoryIncludeSmallCategory(@Param("bigCategoryName") String bigCategoryName, @Param("smallCategoryName") String smallCategoryName);
 
 }

--- a/src/main/java/com/cucumber/market/mapper/ProductMapper.java
+++ b/src/main/java/com/cucumber/market/mapper/ProductMapper.java
@@ -1,5 +1,6 @@
 package com.cucumber.market.mapper;
 
+import com.cucumber.market.dto.product.FindDetailProductResponse;
 import com.cucumber.market.dto.product.FindProductResponse;
 import com.cucumber.market.dto.product.ProductUpdateRequest;
 import com.cucumber.market.dto.product.ProductUploadRequest;
@@ -24,6 +25,10 @@ public interface ProductMapper {
                                                       @Param("offset") int offset,
                                                       @Param("smallCategoryName") String smallCategoryName,
                                                       @Param("findTitle") String findTitle);
+
+    int checkExistProduct(int productIdx);
+
+    FindDetailProductResponse findDetailProduct(int productIdx);
 
     int checkNotSoldOutProduct(int productIdx);
 

--- a/src/main/java/com/cucumber/market/service/CategoryService.java
+++ b/src/main/java/com/cucumber/market/service/CategoryService.java
@@ -23,4 +23,6 @@ public interface CategoryService {
 
     void checkExistSmallCategoryName(String smallCategoryName);
 
+    void checkBigCategoryIncludeSmallCategory(String bigCategoryName, String smallCategoryName);
+
 }

--- a/src/main/java/com/cucumber/market/service/ProductService.java
+++ b/src/main/java/com/cucumber/market/service/ProductService.java
@@ -17,6 +17,10 @@ public interface ProductService {
 
     List<FindProductResponse> findProductByPagination(int pageNum, int contentNum, String smallCategoryName, String title);
 
+    void checkExistProduct(int productIdx);
+
+    FindDetailProductResponse findDetailProduct(int productIdx);
+
     void checkProductWriter(int productIdx, String member_id);
 
     ProductUploadResponse updateProduct(int productIdx, ProductUpdateRequest productUpdateRequest, String member_id);

--- a/src/main/java/com/cucumber/market/service/ProductService.java
+++ b/src/main/java/com/cucumber/market/service/ProductService.java
@@ -11,7 +11,7 @@ public interface ProductService {
                                           List<MultipartFile> multipartFiles,
                                           String member_id) throws IOException;*/
 
-    ProductUploadResponse uploadProduct(ProductUploadRequest productUploadRequest, String member_id);
+    ProductUploadResponse uploadProduct(ProductUploadRequest productUploadRequest);
 
     ProductUploadResponse uploadProductImages(List<MultipartFile> images, String member_id) throws IOException;
 

--- a/src/main/java/com/cucumber/market/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/cucumber/market/service/impl/CategoryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.cucumber.market.service.impl;
 
 import com.cucumber.market.dto.category.*;
+import com.cucumber.market.exception.BigCategoryNotIncludeSmallCategory;
 import com.cucumber.market.exception.CategoryNameNotFoundException;
 import com.cucumber.market.mapper.CategoryMapper;
 import com.cucumber.market.service.CategoryService;
@@ -129,6 +130,18 @@ public class CategoryServiceImpl implements CategoryService {
     public void checkExistSmallCategoryName(String smallCategoryName) {
         if (categoryMapper.checkDuplicateSmallCategoryName(smallCategoryName) == 0) {
             throw new CategoryNameNotFoundException("입력한 소분류명은 존재하지 않습니다.");
+        }
+    }
+
+    /**
+     * 대분류에 속하는 소분류인지 검사 메소드
+     * @param bigCategoryName 대분류명
+     * @param smallCategoryName 소분류명
+     */
+    @Override
+    public void checkBigCategoryIncludeSmallCategory(String bigCategoryName, String smallCategoryName) {
+        if (categoryMapper.checkBigCategoryIncludeSmallCategory(bigCategoryName, smallCategoryName) == 0) {
+            throw new BigCategoryNotIncludeSmallCategory("대분류에 속하지않는 소분류명 입니다.");
         }
     }
 

--- a/src/main/java/com/cucumber/market/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/cucumber/market/service/impl/ProductServiceImpl.java
@@ -119,7 +119,7 @@ public class ProductServiceImpl implements ProductService {
         if (pageNum <= 0)
             throw new PageNoPositiveException("페이지는 1 이상 이어야 합니다.");
 
-        Integer offset = (pageNum - 1) * contentNum;
+        int offset = (pageNum - 1) * contentNum;
 
         String findTitle;
         if(title == null)
@@ -128,6 +128,27 @@ public class ProductServiceImpl implements ProductService {
             findTitle = "%" + title + "%";
 
         return productMapper.findProductByPagination(contentNum, offset, smallCategoryName, findTitle);
+    }
+
+    /**
+     * 판매글 존재여부 검사 메소드
+     * @param productIdx 판매글 번호
+     */
+    @Override
+    public void checkExistProduct(int productIdx) {
+        if (productMapper.checkExistProduct(productIdx) == 0) {
+            throw new NotExistProductException("글번호에 해당하는 판매글이 존재하지 않습니다.");
+        }
+    }
+
+    /**
+     * 판매글 상세조회 메소드
+     * @param productIdx 판매글 번호
+     * @return 판매글 상세정보 (글번호, 작성자, 제목, 내용, 가격, 배송비,  글상태, 수정시간, 해당글의 모든 이미지 경로, 글번호에 속한 댓글번호, 대댓글번호)
+     */
+    @Override
+    public FindDetailProductResponse findDetailProduct(int productIdx) {
+        return productMapper.findDetailProduct(productIdx);
     }
 
     /**

--- a/src/main/java/com/cucumber/market/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/cucumber/market/service/impl/ProductServiceImpl.java
@@ -63,23 +63,13 @@ public class ProductServiceImpl implements ProductService {
 //    }
 
     /**
-     * 판매글 등록 메소드(이미지 파일 포함)
+     * 판매글 등록 메소드
      * @param productUploadRequest 글 등록시 필요한 데이터
-     * @param member_id 현재 접속중인 회원의 아이디
      */
     @Override
-    public ProductUploadResponse uploadProduct(ProductUploadRequest productUploadRequest,
-                                               String member_id) {
-        ProductUploadRequest uploadForm = ProductUploadRequest.builder()
-                .bigCategoryName(productUploadRequest.getBigCategoryName())
-                .smallCategoryName(productUploadRequest.getSmallCategoryName())
-                .title(productUploadRequest.getTitle())
-                .content(productUploadRequest.getContent())
-                .price(productUploadRequest.getPrice())
-                .deliveryPrice(productUploadRequest.getDeliveryPrice())
-                .member_id(member_id).build();
+    public ProductUploadResponse uploadProduct(ProductUploadRequest productUploadRequest) {
 
-        productMapper.uploadProduct(uploadForm); // 글등록(파일제외)
+        productMapper.uploadProduct(productUploadRequest); // 글등록(파일제외)
 
         return ProductUploadResponse.builder()
                 .redirectUrl(productUrl)
@@ -87,7 +77,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     /**
-     * 판매글 등록 시 함께 호출될 썸네일 이미지, 상세페이지 이미지 등록
+     * 판매글 등록 시 함께 호출될 썸네일 이미지, 상세페이지 이미지 등록 메소드
      * @param images 등록한 이미지들
      * @param member_id 로그인한 회원의 아이디
      */

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -48,4 +48,10 @@
         AND big_category_name = #{bigCategoryName}
     </update>
 
+    <select id="checkBigCategoryIncludeSmallCategory" resultType="int">
+        SELECT COUNT(*)
+        FROM small_category
+        WHERE big_category_name = #{bigCategoryName} AND small_category_name = #{smallCategoryName}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/CategoryMapper.xml
+++ b/src/main/resources/mapper/CategoryMapper.xml
@@ -10,7 +10,7 @@
         VALUES (#{bigCategoryName})
     </insert>
 
-    <select id="checkDuplicateBigCategoryName" resultType="Int">
+    <select id="checkDuplicateBigCategoryName" resultType="int">
         SELECT COUNT(big_category_name)
         FROM big_category
         WHERE big_category_name = #{bigCategoryName}
@@ -35,7 +35,7 @@
         VALUES (#{smallCategoryName}, #{bigCategoryName})
     </insert>
 
-    <select id="checkDuplicateSmallCategoryName" resultType="Int">
+    <select id="checkDuplicateSmallCategoryName" resultType="int">
         SELECT COUNT(small_category_name)
         FROM small_category
         WHERE small_category_name = #{smallCategoryName}

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -42,7 +42,8 @@
         </choose>
         LIMIT #{contentNum} OFFSET #{offset}
     </select>
-    <!-- 뷰 상세
+    <!--
+    MySQL View 상세
     CREATE VIEW V_PRODUCT_MAIN AS(
         SELECT
             a.product_idx, a.big_category_name, a.small_category_name, a.title, a.price, a.member_id, a.status, a.updatetime,
@@ -58,6 +59,37 @@
         ORDER BY updatetime DESC
     );
     -->
+
+    <select id="findDetailProduct"
+            resultType="com.cucumber.market.dto.product.FindDetailProductResponse">
+        SELECT *
+        FROM V_PRODUCT_DETAIL
+        WHERE product_idx = #{productIdx}
+    </select>
+    <!--
+    MySQL View 상세
+    CREATE VIEW V_PRODUCT_DETAIL AS(
+        select
+        a.product_idx, a.member_id, a.title, a.content, a.price, a.delivery_price, a.status, a.updatetime,
+        GROUP_CONCAT(DISTINCT b.storefilename) images,
+        GROUP_CONCAT(DISTINCT c.comment_idx) comments,
+        CONCAT(GROUP_CONCAT(DISTINCT d.comment_idx, "/", d.reply_idx)) replies
+    FROM product a
+    LEFT JOIN file b
+    ON a.product_idx = b.product_idx
+    LEFT JOIN comment c
+    ON a.product_idx = c.product_idx
+    LEFT JOIN reply d
+    ON c.comment_idx = d.comment_idx
+    group by a.product_idx
+    );
+    -->
+
+    <select id="checkExistProduct" resultType="int">
+        SELECT COUNT(*)
+        FROM product
+        WHERE product_idx = #{productIdx}
+    </select>
 
     <select id="checkProductWriter" resultType="int">
         SELECT COUNT(*)

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -81,6 +81,7 @@
     ON a.product_idx = c.product_idx
     LEFT JOIN reply d
     ON c.comment_idx = d.comment_idx
+    WHERE a.status = 'a' OR a.status = 'b'
     group by a.product_idx
     );
     -->


### PR DESCRIPTION
**판매글 상세조회 API**
- MySQL View를 활용

장점
1. 특정 사용자에게 테이블 전체가 아닌 필요한 필드만을 보여줄 수 있음
2. 복잡한 쿼리를 단순화해서 사용할 수 있음
3. 쿼리를 재사용할 수 있음

단점
1. 독립적인 인덱스를 가질 수 없음
2. ALTER VIEW문을 사용할 수 없음 (즉, 뷰의 정의를 변경할 수 없음)
3. 뷰로 구성된 내용에 대한 삽입, 삭제, 갱신, 연산에 제약이 따름

**판매글 등록 API에서 Multipart 관련 이슈**
- Multipart form 데이터가 URL Query String 형식으로 Request가 전달되던 형식에서
Body로 전달되는 형식으로 변경하기 위해 MultipartResolver 적용
- MultipartFile이 Request에서 null로 전달되던 형식에서
"Multipart/form-data" MediaType을 적용하여 null이 전달되지 않도록 적용