### PR TITLE
logback 라이브러리의 취약점 (공격자가 취약점을 이용하여 원격코드 실행) 대응을 위한 안정화 버전 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,15 @@ configurations {
 	}
 }
 
+configurations.all {
+	resolutionStrategy.eachDependency { details ->
+		if (details.requested.group == 'ch.qos.logback') {
+			details.useVersion '1.2.9'
+			details.because 'vulnerability'
+		}
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -41,7 +50,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
+	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.0'
 
 }
 


### PR DESCRIPTION
### 취약점
공격자가 취약점을 이용하여 원격코드 실행

### 대응
1.2.9 버전 이상으로 업그레이드 하는 것을 권고하고 있음

현재 Spring Boot 2.5.7 버전 기준으로
`spring-boot-starter-web` dependency에 있는 logback의 버전은 1.2.7

따라서 해당 Groovy DSL 적용